### PR TITLE
Hotfix for assets in serve, and disable overwriting theme on install

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -4,6 +4,7 @@ namespace Portable\FilaCms\Commands;
 
 use Filament\Support\Commands\InstallCommand as CommandsInstallCommand;
 use Filament\Support\Commands\UpgradeCommand;
+use Illuminate\Support\Facades\File;
 
 class InstallCommand extends CommandsInstallCommand
 {
@@ -56,7 +57,10 @@ class InstallCommand extends CommandsInstallCommand
 
         // @codeCoverageIgnoreStart
         if(!app()->runningUnitTests()) {
-            $this->callSilent('make:filament-theme');
+            // Only call this if there isn't already a filament theme
+            if(!File::exists(resource_path('css/filament/admin/theme.css'))) {
+                $this->callSilent('make:filament-theme');
+            }
         }
         // @codeCoverageIgnoreEnd
 

--- a/tests/Listeners/CommandStartingListener.php
+++ b/tests/Listeners/CommandStartingListener.php
@@ -33,11 +33,12 @@ class CommandStartingListener
         File::delete(resource_path('css/filament/admin/tailwind.config.js'));
         File::delete(resource_path('css/filament/admin/theme.css'));
 
-        copy(getcwd() . '/vite.config.js', resource_path('../vite.config.js'));
-        copy(getcwd() . '/resources/css/filacms.css', resource_path('css/filacms.css'));
-        copy(getcwd() . '/package.json', resource_path('../package.json'));
+        File::copy(getcwd() . '/vite.config.js', resource_path('../vite.config.js'));
+        File::ensureDirectoryExists(resource_path('css'));
+        File::copy(getcwd() . '/resources/css/filacms.css', resource_path('css/filacms.css'));
+        File::copy(getcwd() . '/package.json', resource_path('../package.json'));
 
-        Artisan::call('fila-cms:install', ['--publish-config' => true,'--run-migrations' => true,'--add-user-traits' => false]);
+        Artisan::call('fila-cms:install', ['--publish-config' => true,'--run-migrations' => true,'--add-user-traits' => true]);
 
         // Ensure there's an admin user
         $userModel = config('auth.providers.users.model');


### PR DESCRIPTION
Wee one to fix assets in FE (you should now be able to view default front end pages with testbench serve!)

Also, no longer overwrites your css and things if you run fila-cms:install multiple times