### PR TITLE
VG-13 fix: Attempt to use a URL with an unsupported scheme

### DIFF
--- a/src/Filament/Resources/AbstractContentResource.php
+++ b/src/Filament/Resources/AbstractContentResource.php
@@ -292,6 +292,7 @@ class AbstractContentResource extends AbstractResource
                         ->schema([
                             TextInput::make('url')
                                 ->unique(ignoreRecord: true)
+                                ->rules(['alpha_dash'])
                                 ->live(onBlur: true)
                                 ->required()
                                 ->hintColor('info')
@@ -315,19 +316,12 @@ class AbstractContentResource extends AbstractResource
 
                         ])
                         ->itemLabel(function (array $state) use ($prefixUrl) {
-
                             $label = '';
                             if($state['enable'] === false) {
                                 $label .= '[Disabled] - ';
                             }
-
                             $label .= $prefixUrl . Str::slug($state['url'] ?? null);
-
                             return $label;
-                        })
-                        ->mutateRelationshipDataBeforeFillUsing(function (array $data): array {
-                            $data['url'] = Str::slug($data['url']);
-                            return $data;
                         })
                         ->mutateRelationshipDataBeforeCreateUsing(function (array $data): array {
                             $data['url'] = Str::slug($data['url']);


### PR DESCRIPTION
Fix for: Attempt to use a URL with an unsupported scheme (e.g., "ftp://[www.example.com](http://www.example.com/)" or @gmail.com ) in the "Legacy or Vanity URL" field.

and database unique validation.