### PR TITLE
Add forms to menus, fix FE routing prefixes

### DIFF
--- a/database/migrations/2024_04_15_000000_add_parent_id_to_taxonomy_terms.php
+++ b/database/migrations/2024_04_15_000000_add_parent_id_to_taxonomy_terms.php
@@ -21,7 +21,9 @@ return new class () extends Migration {
     public function down(): void
     {
         Schema::table('taxonomy_terms', function (Blueprint $table) {
-            $table->dropForeign('taxonomy_terms_parent_id_foreign');
+            if(config('database.default') !== 'sqlite') {
+                $table->dropForeign('taxonomy_terms_parent_id_foreign');
+            }
         });
     }
 };

--- a/database/migrations/2024_04_15_000000_add_parent_id_to_taxonomy_terms.php
+++ b/database/migrations/2024_04_15_000000_add_parent_id_to_taxonomy_terms.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class () extends Migration {
@@ -21,7 +22,7 @@ return new class () extends Migration {
     public function down(): void
     {
         Schema::table('taxonomy_terms', function (Blueprint $table) {
-            if(config('database.default') !== 'sqlite') {
+            if(DB::connection()->getDriverName() !== 'sqlite') {
                 $table->dropForeign('taxonomy_terms_parent_id_foreign');
             }
         });

--- a/database/migrations/2024_04_26_000001_create_menu_items_table.php
+++ b/database/migrations/2024_04_26_000001_create_menu_items_table.php
@@ -32,7 +32,9 @@ return new class () extends Migration {
     public function down(): void
     {
         Schema::table('menu_items', function (Blueprint $table) {
-            $table->dropForeign('menu_items_parent_id_foreign');
+            if(config('database.default') !== 'sqlite') {
+                $table->dropForeign('menu_items_parent_id_foreign');
+            }
         });
         Schema::dropIfExists('menu_items');
     }

--- a/database/migrations/2024_04_26_000001_create_menu_items_table.php
+++ b/database/migrations/2024_04_26_000001_create_menu_items_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class () extends Migration {
@@ -32,7 +33,7 @@ return new class () extends Migration {
     public function down(): void
     {
         Schema::table('menu_items', function (Blueprint $table) {
-            if(config('database.default') !== 'sqlite') {
+            if(DB::connection()->getDriverName() !== 'sqlite') {
                 $table->dropForeign('menu_items_parent_id_foreign');
             }
         });

--- a/database/migrations/2024_05_17_000001_adjust_page_authors.php
+++ b/database/migrations/2024_05_17_000001_adjust_page_authors.php
@@ -19,7 +19,7 @@ return new class () extends Migration {
 
 
         Schema::table('pages', function (Blueprint $table) {
-            if(!app()->environment('testing')) {
+            if(config('database.default') !== 'sqlite') {
                 $table->dropConstrainedForeignId('author_id');
             }
         });

--- a/database/migrations/2024_05_17_000001_adjust_page_authors.php
+++ b/database/migrations/2024_05_17_000001_adjust_page_authors.php
@@ -19,8 +19,10 @@ return new class () extends Migration {
 
 
         Schema::table('pages', function (Blueprint $table) {
-            if(config('database.default') !== 'sqlite') {
+            try {
                 $table->dropConstrainedForeignId('author_id');
+            } catch(\Exception $e) {
+                // This fails cause we're using Sqlite in testing, ignore
             }
         });
     }

--- a/database/migrations/2024_05_17_000001_adjust_page_authors.php
+++ b/database/migrations/2024_05_17_000001_adjust_page_authors.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Portable\FilaCms\Models\Page;
 
@@ -19,10 +20,8 @@ return new class () extends Migration {
 
 
         Schema::table('pages', function (Blueprint $table) {
-            try {
+            if(DB::connection()->getDriverName() !== 'sqlite') {
                 $table->dropConstrainedForeignId('author_id');
-            } catch(\Exception $e) {
-                // This fails cause we're using Sqlite in testing, ignore
             }
         });
     }

--- a/src/Filament/Resources/AbstractContentResource.php
+++ b/src/Filament/Resources/AbstractContentResource.php
@@ -24,8 +24,8 @@ use Filament\Tables\Actions\Action;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
-
 use Illuminate\Database\Eloquent\Builder;
+
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\HtmlString;
@@ -34,6 +34,8 @@ use Portable\FilaCms\Facades\FilaCms;
 use Portable\FilaCms\Filament\Forms\Components\StatusBadge;
 use Portable\FilaCms\Filament\Resources\AbstractContentResource\Pages;
 use Portable\FilaCms\Filament\Traits\IsProtectedResource;
+use Portable\FilaCms\Livewire\ContentResourceList;
+use Portable\FilaCms\Livewire\ContentResourceShow;
 use Portable\FilaCms\Models\Author;
 use Portable\FilaCms\Models\Page;
 use Portable\FilaCms\Models\Scopes\PublishedScope;
@@ -49,6 +51,41 @@ class AbstractContentResource extends AbstractResource
     protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
 
     protected static ?string $navigationGroup = 'Content';
+
+    public static function getFrontendRoutePrefix()
+    {
+        return static::getRoutePrefix();
+    }
+
+    public static function getFrontendShowRoute()
+    {
+        return static::getFrontendRoutePrefix() . '.{slug}';
+    }
+
+    public static function getFrontendIndexRoute()
+    {
+        return static::getFrontendRoutePrefix() . '.index';
+    }
+
+    public static function registerIndexRoute()
+    {
+        return true;
+    }
+
+    public static function registerShowRoute()
+    {
+        return true;
+    }
+
+    public static function getFrontendIndexComponent()
+    {
+        return ContentResourceList::class;
+    }
+
+    public static function getFrontendShowComponent()
+    {
+        return ContentResourceShow::class;
+    }
 
     public static function getEloquentQuery(): Builder
     {

--- a/src/Filament/Resources/FormResource.php
+++ b/src/Filament/Resources/FormResource.php
@@ -30,6 +30,31 @@ class FormResource extends AbstractResource
 
     protected static ?string $navigationGroup = 'Forms';
 
+    public static function getFrontendRoutePrefix()
+    {
+        return static::getRoutePrefix();
+    }
+
+    public static function getFrontendShowRoute()
+    {
+        return static::getFrontendRoutePrefix() . '.{slug}';
+    }
+
+    public static function getFrontendIndexRoute()
+    {
+        return static::getFrontendRoutePrefix() . '.index';
+    }
+
+    public static function registerIndexRoute()
+    {
+        return false;
+    }
+
+    public static function registerShowRoute()
+    {
+        return true;
+    }
+
     public static function form(Form $form): Form
     {
 

--- a/src/Filament/Resources/MenuItemResource.php
+++ b/src/Filament/Resources/MenuItemResource.php
@@ -8,11 +8,11 @@ use Filament\Forms\Get;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-
 use Illuminate\Support\Str;
 use Portable\FilaCms\Facades\FilaCms;
 use Portable\FilaCms\Filament\Resources\MenuItemResource\Pages;
 use Portable\FilaCms\Filament\Traits\IsProtectedResource;
+use Portable\FilaCms\Models\Form as FormModel;
 use Portable\FilaCms\Models\MenuItem;
 
 class MenuItemResource extends AbstractResource
@@ -72,7 +72,7 @@ class MenuItemResource extends AbstractResource
                         Forms\Components\Select::make('reference_page')
                             ->label('Content Type')
                             ->visible(fn (Get $get) => $get('type') !== 'url' ? true : false)
-                            ->options(FilaCms::getContentModels())
+                            ->options(static::getContentSources())
                             ->required()
                             ->live()
                             ->columnSpan(2),
@@ -110,11 +110,7 @@ class MenuItemResource extends AbstractResource
             ->columns([
                 TextColumn::make('name')->sortable(),
                 TextColumn::make('type')->label('Type'),
-                TextColumn::make('order')->label('Order'),
                 TextColumn::make('parent.name')->label('Parent'),
-            ])
-            ->filters([
-
             ])
             ->headerActions([
                 Tables\Actions\CreateAction::make(),
@@ -128,6 +124,14 @@ class MenuItemResource extends AbstractResource
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ])->defaultSort('order');
+    }
+
+    public static function getContentSources()
+    {
+        $sources = FilaCms::getContentModels();
+        $sources[FormResource::class] = 'Forms';
+
+        return $sources;
     }
 
     public static function getRelations(): array
@@ -177,6 +181,9 @@ class MenuItemResource extends AbstractResource
     protected function getSourceModel($source)
     {
         $className = FilaCms::getModelFromResource($source);
+        if(!$className) {
+            $className = FormModel::class;
+        }
 
         return new $className();
     }

--- a/src/Filament/Resources/PageResource.php
+++ b/src/Filament/Resources/PageResource.php
@@ -8,6 +8,18 @@ class PageResource extends AbstractContentResource
 {
     protected static ?string $recordTitleAttribute = 'title';
 
+    public static function getFrontendRoutePrefix()
+    {
+        // So that pages just register as /{slug} instead of /pages/{slug}
+        return '';
+    }
+
+    public static function registerIndexRoute()
+    {
+        // We don't want a "Pages" listing page
+        return false;
+    }
+
     public static function getPages(): array
     {
         return [

--- a/src/Http/Middleware/ContentRoleMiddleware.php
+++ b/src/Http/Middleware/ContentRoleMiddleware.php
@@ -4,9 +4,9 @@ namespace Portable\FilaCms\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Support\Str;
 use Portable\FilaCms\Facades\FilaCms;
+use Symfony\Component\HttpFoundation\Response;
 
 class ContentRoleMiddleware
 {
@@ -21,7 +21,7 @@ class ContentRoleMiddleware
 
         $path = $request->path();
         foreach ($contentModels as $modelClass => $resourceClass) {
-            $prefix = method_exists($resourceClass, 'getFrontendRoutePrefix') ? $resourceClass::getFrontendRoutePrefix() : $resourceClass::getRoutePrefix();
+            $prefix = $resourceClass::getFrontendRoutePrefix();
 
             if (Str::of($path)->startsWith($prefix . '/')) {
                 $slug = Str::of($path)->replace($prefix . '/', '');

--- a/src/Livewire/ContentResourceList.php
+++ b/src/Livewire/ContentResourceList.php
@@ -84,12 +84,11 @@ class ContentResourceList extends Component implements HasForms
     protected function getViewData()
     {
         $resourceClass = FilaCms::getContentModelResource($this->model);
-        $prefix = method_exists($resourceClass, 'getFrontendRoutePrefix') ? $resourceClass::getFrontendRoutePrefix() : $resourceClass::getRoutePrefix();
 
         return [
             'results' => $this->getResultsQuery()->paginate(10),
             'title' => Str::title($resourceClass::getPluralModelLabel()),
-            'showRoute' => $prefix.'.show',
+            'showRoute' => $resourceClass::getFrontendShowRoute()
         ];
     }
 }

--- a/src/Livewire/ContentResourceShow.php
+++ b/src/Livewire/ContentResourceShow.php
@@ -54,10 +54,9 @@ class ContentResourceShow extends Component implements HasForms
     protected function getViewData()
     {
         $resourceClass = FilaCms::getContentModelResource($this->model);
-        $prefix = method_exists($resourceClass, 'getFrontendRoutePrefix') ? $resourceClass::getFrontendRoutePrefix() : $resourceClass::getRoutePrefix();
 
         return [
-            'showRoute' => $prefix.'.show',
+            'showRoute' => $resourceClass::getFrontendShowRoute()
         ];
     }
 }

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -30,4 +30,10 @@ class Menu extends Model
     {
         return $this->hasMany(MenuItem::class, 'menu_id');
     }
+
+    // Return only direct descendants
+    public function children()
+    {
+        return $this->items()->whereNull('parent_id');
+    }
 }

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -69,12 +69,11 @@ class MenuItem extends Model
     public function url(): Attribute
     {
         return new Attribute(function ($value) {
+            $resourceClass = $this->reference_page;
             switch($this->type) {
                 case 'index-page':
-                    $resourceClass = $this->reference_page;
                     return route($resourceClass::getFrontendIndexRoute());
                 case 'content':
-                    $resourceClass = $this->reference_page;
                     $slug = ($resourceClass::getModel())::find($this->reference_content)?->slug;
 
                     return route($resourceClass::getFrontendShowRoute(), ['slug' => $slug]);

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -66,6 +66,24 @@ class MenuItem extends Model
         return $this->belongsTo(Menu::class, 'menu_id');
     }
 
+    public function url(): Attribute
+    {
+        return new Attribute(function ($value) {
+            switch($this->type) {
+                case 'index-page':
+                    $resourceClass = $this->reference_page;
+                    return route($resourceClass::getFrontendIndexRoute());
+                case 'content':
+                    $resourceClass = $this->reference_page;
+                    $slug = ($resourceClass::getModel())::find($this->reference_content)?->slug;
+
+                    return route($resourceClass::getFrontendShowRoute(), ['slug' => $slug]);
+                default: // 'url'
+                    return $this->reference_text ?? '#';
+            }
+        });
+    }
+
     public function referenceText(): Attribute
     {
         return Attribute::make(

--- a/tests/Filament/MenuItemResourceTest.php
+++ b/tests/Filament/MenuItemResourceTest.php
@@ -91,7 +91,7 @@ class MenuItemResourceTest extends TestCase
         $data = MenuItem::factory()->create([
             'menu_id' => $menu->id,
             'type' => 'index-page',
-            'reference_page' => 'Portable\FilaCms\Filament\Resources\PageResource',
+            'reference_page' => \Portable\FilaCms\Filament\Resources\PageResource::class,
         ]);
 
         $resourceClass = $data->reference_page;
@@ -107,7 +107,7 @@ class MenuItemResourceTest extends TestCase
         $data = MenuItem::factory()->create([
             'menu_id' => $menu->id,
             'type' => 'content',
-            'reference_page' => 'Portable\FilaCms\Filament\Resources\PageResource',
+            'reference_page' => \Portable\FilaCms\Filament\Resources\PageResource::class,
             'reference_content' => $page->id
         ]);
 
@@ -124,7 +124,7 @@ class MenuItemResourceTest extends TestCase
         $data = MenuItem::factory()->create([
             'menu_id' => $menu->id,
             'type' => 'content',
-            'reference_page' => 'Portable\FilaCms\Filament\Resources\FormResource',
+            'reference_page' => \Portable\FilaCms\Filament\Resources\FormResource::class,
             'reference_content' => $form->id
         ]);
 

--- a/tests/Filament/MenuItemResourceTest.php
+++ b/tests/Filament/MenuItemResourceTest.php
@@ -7,8 +7,10 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Livewire\Livewire;
 use Portable\FilaCms\Filament\Resources\MenuResource\Pages\EditMenu;
 use Portable\FilaCms\Filament\Resources\MenuResource\RelationManagers\ItemsRelationManager;
+use Portable\FilaCms\Models\Form;
 use Portable\FilaCms\Models\Menu;
 use Portable\FilaCms\Models\MenuItem;
+use Portable\FilaCms\Models\Page;
 use Portable\FilaCms\Tests\TestCase;
 use Spatie\Permission\Models\Role;
 
@@ -81,5 +83,54 @@ class MenuItemResourceTest extends TestCase
             'Item 4',
             'Item 5',
         ]);
+    }
+
+    public function test_index_url()
+    {
+        $menu = Menu::factory()->create();
+        $data = MenuItem::factory()->create([
+            'menu_id' => $menu->id,
+            'type' => 'index-page',
+            'reference_page' => 'Portable\FilaCms\Filament\Resources\PageResource',
+        ]);
+
+        $resourceClass = $data->reference_page;
+        $route = route($resourceClass::getFrontendIndexRoute());
+
+        $this->assertEquals($route, $data->url);
+    }
+
+    public function test_page_url()
+    {
+        $page = Page::factory()->create();
+        $menu = Menu::factory()->create();
+        $data = MenuItem::factory()->create([
+            'menu_id' => $menu->id,
+            'type' => 'content',
+            'reference_page' => 'Portable\FilaCms\Filament\Resources\PageResource',
+            'reference_content' => $page->id
+        ]);
+
+        $resourceClass = $data->reference_page;
+        $route = route($resourceClass::getFrontendShowRoute(), $page->slug);
+
+        $this->assertEquals($route, $data->url);
+    }
+
+    public function test_form_url()
+    {
+        $form = Form::factory()->create();
+        $menu = Menu::factory()->create();
+        $data = MenuItem::factory()->create([
+            'menu_id' => $menu->id,
+            'type' => 'content',
+            'reference_page' => 'Portable\FilaCms\Filament\Resources\FormResource',
+            'reference_content' => $form->id
+        ]);
+
+        $resourceClass = $data->reference_page;
+        $route = route($resourceClass::getFrontendShowRoute(), $form->slug);
+
+        $this->assertEquals($route, $data->url);
     }
 }


### PR DESCRIPTION
Minor fix ups to make FE routing neater, remove the 'pages' prefix for page routes, and allow forms to be a menu item target.