### PR TITLE
vg 264 - media manager

### DIFF
--- a/resources/views/admin/livewire/media-library-table.blade.php
+++ b/resources/views/admin/livewire/media-library-table.blade.php
@@ -1,45 +1,43 @@
 <div>
-  <ol class="fi-breadcrumbs-list flex flex-wrap items-center gap-x-2 mb-2">
-    @foreach ($this->breadcrumbs() as $link => $breadcrumb)
-      <li class="fi-breadcrumbs-item flex gap-x-2">
-        @if (!$loop->first)
-          <svg class="fi-breadcrumbs-item-separator flex h-5 w-5 text-gray-400 dark:text-gray-500 rtl:hidden"
+  <ol class="flex flex-wrap items-center mb-2 fi-breadcrumbs-list gap-x-2">
+        @foreach ($this->breadcrumbs() as $link => $breadcrumb)
+      <li class="flex fi-breadcrumbs-item gap-x-2">
+                @if (!$loop->first)
+          <svg class="flex w-5 h-5 text-gray-400 fi-breadcrumbs-item-separator dark:text-gray-500 rtl:hidden"
             xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-            <path fill-rule="evenodd"
-              d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
-              clip-rule="evenodd"></path>
-          </svg>
-          <svg class="fi-breadcrumbs-item-separator flex h-5 w-5 text-gray-400 dark:text-gray-500 ltr:hidden"
-            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"
-            data-slot="icon">
-            <path fill-rule="evenodd"
-              d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z"
-              clip-rule="evenodd"></path>
-          </svg>
-        @endif
-        <a href="javascript:setParent('{{ $link }}')"
-          class="fi-breadcrumbs-item-label text-sm font-medium text-gray-500 transition duration-75 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
-          {{ $breadcrumb }}
-        </a>
-      </li>
-    @endforeach
-  </ol>
-  @script
-    <script>
-      window.setParent = function(id) {
-        $wire.call('setParent', id);
-        $wire.$refresh();
-      }
-      Livewire.on('set-current-parent-cookie', (id) => {        
-        var currentDate = new Date();
-        // Calculate the expiry time for one week
-        var expiryDate = new Date(currentDate.getTime() + (24 * 60 * 60 * 1000));
-        // Convert the expiry date to UTC format
-        var expires = expiryDate.toUTCString();
-        // Set the cookie with the specified key, value, and expiry
-        document.cookie = "{{$this->cookieKey}}=" + encodeURIComponent(id) + "; expires=" + expires + "; path=/";  
-      });
-    </script>
-  @endscript
-  {{ $this->table }}
+                        <path fill-rule="evenodd"
+                            d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+                            clip-rule="evenodd"></path>
+                    </svg>
+          <svg class="flex w-5 h-5 text-gray-400 fi-breadcrumbs-item-separator dark:text-gray-500 ltr:hidden"
+                        xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"
+                        data-slot="icon">
+                        <path fill-rule="evenodd"
+                            d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z"
+                            clip-rule="evenodd"></path>
+                    </svg>
+                @endif
+                <a href="javascript:setParent('{{ $link }}')"
+          class="text-sm font-medium text-gray-500 transition duration-75 fi-breadcrumbs-item-label hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+                    {{ $breadcrumb }}
+                </a>
+            </li>
+        @endforeach
+    </ol>
+    @script
+        <script>
+            window.setParent = function(id) {
+                $wire.call('setParent', id);
+                $wire.$refresh();
+            }
+            Livewire.on('set-current-parent-cookie', (id) => {
+                var currentDate = new Date();
+                // Calculate the expiry time for 1 day
+                var expiryDate = new Date(currentDate.getTime() + (24 * 60 * 60 * 1000));        
+                var expires = expiryDate.toUTCString();
+                document.cookie = "{{ $this->cookieKey }}=" + encodeURIComponent(id) + "; expires=" + expires +"; path=/";
+            });
+        </script>
+    @endscript
+    {{ $this->table }}
 </div>

--- a/resources/views/admin/livewire/media-library-table.blade.php
+++ b/resources/views/admin/livewire/media-library-table.blade.php
@@ -30,6 +30,15 @@
         $wire.call('setParent', id);
         $wire.$refresh();
       }
+      Livewire.on('set-current-parent-cookie', (id) => {        
+        var currentDate = new Date();
+        // Calculate the expiry time for one week
+        var expiryDate = new Date(currentDate.getTime() + (24 * 60 * 60 * 1000));
+        // Convert the expiry date to UTC format
+        var expires = expiryDate.toUTCString();
+        // Set the cookie with the specified key, value, and expiry
+        document.cookie = "{{$this->cookieKey}}=" + encodeURIComponent(id) + "; expires=" + expires + "; path=/";  
+      });
     </script>
   @endscript
   {{ $this->table }}

--- a/src/Livewire/MediaLibraryTable.php
+++ b/src/Livewire/MediaLibraryTable.php
@@ -313,8 +313,6 @@ class MediaLibraryTable extends Component implements HasForms, HasTable
                                 ]),
                     ])
                     ->reorderable(false)
-                    ->addActionLabel('Upload more')
-
             ])
             ->action(function (array $data) {
                 if(count($data['upload_media'])) {

--- a/src/Livewire/MediaLibraryTable.php
+++ b/src/Livewire/MediaLibraryTable.php
@@ -27,6 +27,7 @@ use Livewire\Component;
 use Portable\FilaCms\Filament\Tables\Columns\ThumbnailColumn;
 use Portable\FilaCms\Models\Media;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Filament\Forms\Components\Repeater;
 
 class MediaLibraryTable extends Component implements HasForms, HasTable
 {
@@ -241,24 +242,28 @@ class MediaLibraryTable extends Component implements HasForms, HasTable
     {
         $action = Action::make('upload')
             ->form([
-                FileUpload::make('upload_media')
-                    ->label('Upload File')
-                    ->storeFiles(false)
-                    ->multiple()
-                    ->required(),
-                TextInput::make('alt_text')
-                    ->label('Alt Text')
-                    ->required()
+                Repeater::make('upload_media_group')
+                    ->label('')
+                    ->schema([
+                        Group::make()
+                            ->schema([
+                                FileUpload::make('upload_media')
+                                    ->label('Upload File')
+                                    ->storeFiles(false)
+                                    ->required(),
+                                TextInput::make('alt_text')
+                                        ->label('Alt Text')
+                                        ->required(),
+                                ]),
+                    ])
+                    ->reorderable(false)
+                    ->addActionLabel('Upload more')
 
             ])
             ->action(function (array $data) {
-                if(!is_array($data['upload_media'])) {
-                    $this->saveFile($data['upload_media'], $data['alt_text']);
-                    return;
-                }
-                if(count($data['upload_media'])) {
-                    foreach($data['upload_media'] as $item) {
-                        $this->saveFile($item, $data['alt_text']);
+                if(count($data['upload_media_group'])) {
+                    foreach($data['upload_media_group'] as $item) {
+                        $this->saveFile($item['upload_media'], $item['alt_text']);
                     }
                 }
             })

--- a/src/Livewire/MediaLibraryTable.php
+++ b/src/Livewire/MediaLibraryTable.php
@@ -35,10 +35,13 @@ class MediaLibraryTable extends Component implements HasForms, HasTable
     public $current_parent;
     public $current_file;
     public $jsKey;
+    public $cookieKey = 'media_library_parent';
 
     public function mount($jsKey = null)
     {
         $this->jsKey = $jsKey ?: $this->id();
+
+        $this->setParent($_COOKIE[$this->cookieKey] ?? null);
     }
 
     public function breadcrumbs()
@@ -62,9 +65,15 @@ class MediaLibraryTable extends Component implements HasForms, HasTable
 
     public function setParent($id)
     {
+        if(!Media::find($id)) {
+            $id = null;
+        }
+
         $this->current_parent = Str::replace('id-', '', $id);
         $this->current_file = null;
         $this->dispatch('media-file-selected', ['id' => null, 'jsKey' => $this->jsKey ]);
+        $this->dispatch('set-current-parent-cookie', $id);
+
     }
 
     public function setFile($id)

--- a/src/Livewire/MediaLibraryTable.php
+++ b/src/Livewire/MediaLibraryTable.php
@@ -242,7 +242,7 @@ class MediaLibraryTable extends Component implements HasForms, HasTable
         $action = Action::make('upload')
             ->form([
                 FileUpload::make('upload_media')
-                    ->label('Upload File')                    
+                    ->label('Upload File')
                     ->storeFiles(false)
                     ->multiple()
                     ->required(),
@@ -251,13 +251,13 @@ class MediaLibraryTable extends Component implements HasForms, HasTable
                     ->required()
 
             ])
-            ->action(function (array $data) {                
+            ->action(function (array $data) {
                 if(!is_array($data['upload_media'])) {
-                    $this->saveFile($data['upload_media'], $data['alt_text']);                    
+                    $this->saveFile($data['upload_media'], $data['alt_text']);
                     return;
-                } 
+                }
                 if(count($data['upload_media'])) {
-                    foreach( $data['upload_media'] as $item ) {
+                    foreach($data['upload_media'] as $item) {
                         $this->saveFile($item, $data['alt_text']);
                     }
                 }


### PR DESCRIPTION
> Is is possible to make the following improvements to our media manager? 
> 
> The client would like to be able to bulk drag and drop or select multiple images to drop in at once
> 
> When going back to choose an image from the folder, is it possible to keep the media pop up at the last folder they were in? 
> 
> For example, we have several layers of folders and they often want to be able to choose different images from the same folder and having to navigate back to the folder (several clicks away) can be a bit inefficient.