### PR TITLE
fix: LinkedIn SSO using linkedin-openid service

### DIFF
--- a/src/Http/Controllers/SSOController.php
+++ b/src/Http/Controllers/SSOController.php
@@ -20,27 +20,37 @@ class SSOController extends Controller
     {
         $driver = preg_match("/login\/(.*)/", Route::current()->uri(), $matches) ? $matches[1] : null;
 
-        config(['services.' . $driver => [
+        $socialiteDriver = $driver;
+        if(Str::lower($socialiteDriver) === 'linkedin') {
+            $socialiteDriver = 'linkedin-openid';
+        }
+
+        config(['services.' . $socialiteDriver => [
             'client_id' => config('settings.sso.' . $driver . '.client_id'),
             'client_secret' => config('settings.sso.' . $driver . '.client_secret'),
             'redirect' => config('app.url') . '/login/' . $driver . '/callback',
         ]]);
 
-        return Socialite::driver($driver)->redirect();
+        return Socialite::driver($socialiteDriver)->redirect();
     }
 
     public function handleProviderCallback(LoginResponse $loginResponse)
     {
         $driver = preg_match("/login\/(.*)\//", Route::current()->uri(), $matches) ? $matches[1] : null;
 
-        config(['services.' . $driver => [
+        $socialiteDriver = $driver;
+        if(Str::lower($socialiteDriver) === 'linkedin') {
+            $socialiteDriver = 'linkedin-openid';
+        }
+
+        config(['services.' . $socialiteDriver => [
             'client_id' => config('settings.sso.' . $driver . '.client_id'),
             'client_secret' => config('settings.sso.' . $driver . '.client_secret'),
             'redirect' => config('app.url') . '/login/' . $driver . '/callback',
         ]]);
 
         $userModel = config('auth.providers.users.model');
-        $ssoUser = Socialite::driver($driver)->user();
+        $ssoUser = Socialite::driver($socialiteDriver)->user();
         $ssoLink = UserSsoLink::where('driver', $driver)->where('provider_id', $ssoUser->getId())->first();
 
         if (!$ssoLink) {

--- a/src/Providers/FilaCmsServiceProvider.php
+++ b/src/Providers/FilaCmsServiceProvider.php
@@ -34,6 +34,7 @@ use Portable\FilaCms\Listeners\UserVerifiedListener;
 use Portable\FilaCms\Models\Setting;
 use Portable\FilaCms\Observers\AuthenticatableObserver;
 use Portable\FilaCms\Services\MediaLibrary;
+use Illuminate\Support\HtmlString;
 
 class FilaCmsServiceProvider extends ServiceProvider
 {
@@ -296,8 +297,12 @@ class FilaCmsServiceProvider extends ServiceProvider
                 TextInput::make('sso.linkedin.client_secret')->label('Client Secret'),
                 Placeholder::make('sso.linkedin.redirect')
                     ->label('Redirect Url')
-                    ->content(url('login/linked/callback'))
+                    ->content(url('login/linkedin/callback'))
                     ->helperText('Use this as the redirect url in your LinkedIn app settings'),
+                Placeholder::make('added_product')
+                    ->label('App Requirement')
+                    ->content(new HtmlString('<strong>OpenID Connect</strong>'))
+                    ->helperText('Within the Products section, locate and enable "Sign In with LinkedIn using OpenID Connect"'),
             ];
         });
     }


### PR DESCRIPTION
Use linkedin-openid service.

![image](https://github.com/PortableStudios/fila-cms/assets/166683621/ddd2bdac-e2bd-44d6-ac9c-f9a1956da1ea)

With the recent changes, make sure the linkedin app supports OpenID Connect

![image](https://github.com/PortableStudios/fila-cms/assets/166683621/46071c10-2f46-4908-8d1a-bbf508412ffc)


reference: https://github.com/laravel/socialite/issues/309#issuecomment-2002337659