### PR TITLE
Fix/vg 384 form creation

### DIFF
--- a/src/Filament/FormBlocks/AbstractFormBlock.php
+++ b/src/Filament/FormBlocks/AbstractFormBlock.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Forms\Components\Builder\Block;
 use Filament\Forms\Components\Component;
 use Illuminate\Support\Collection;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 abstract class AbstractFormBlock extends Block
 {
@@ -45,11 +46,14 @@ abstract class AbstractFormBlock extends Block
     public static function getField($fieldData, $readOnly = false): Component
     {
         // Validate field data
-
         $field = static::createField($fieldData, $readOnly);
         $field = static::applyRequirementFields($field, $fieldData);
         if ($readOnly && method_exists($field, 'readOnly')) {
             $field->readOnly();
+        }
+        $field->label($fieldData['field_name'] ?? $fieldData['field_id'] ?? '-');
+        if(!empty($fieldData['field_id'])) {
+            $field->statePath($fieldData['field_id']);
         }
 
         return $field;
@@ -65,13 +69,11 @@ abstract class AbstractFormBlock extends Block
 
     public static function displayValue($fieldData, $values): string
     {
-        $fieldName = data_get($fieldData, 'field_name');
-        $value = isset($values[$fieldName]) ? $values[$fieldName] : [];
-
+        $value = FormBuilder::getFormInputValue($fieldData, $values);
+        
         if (is_array($value)) {
             $value = implode(', ', $value);
         }
-
         return $value;
     }
 

--- a/src/Filament/FormBlocks/AbstractFormBlock.php
+++ b/src/Filament/FormBlocks/AbstractFormBlock.php
@@ -6,7 +6,6 @@ use Closure;
 use Filament\Forms\Components\Builder\Block;
 use Filament\Forms\Components\Component;
 use Illuminate\Support\Collection;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 abstract class AbstractFormBlock extends Block
 {
@@ -70,7 +69,7 @@ abstract class AbstractFormBlock extends Block
     public static function displayValue($fieldData, $values): string
     {
         $value = FormBuilder::getFormInputValue($fieldData, $values);
-        
+
         if (is_array($value)) {
             $value = implode(', ', $value);
         }

--- a/src/Filament/FormBlocks/AbstractOptionsBlock.php
+++ b/src/Filament/FormBlocks/AbstractOptionsBlock.php
@@ -9,6 +9,7 @@ use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 abstract class AbstractOptionsBlock extends AbstractFormBlock
 {
@@ -100,8 +101,8 @@ abstract class AbstractOptionsBlock extends AbstractFormBlock
 
     public static function displayValue($fieldData, $values): string
     {
-        $fieldName = data_get($fieldData, 'field_name');
-        $value = isset($values[$fieldName]) ? $values[$fieldName] : [];
+        $value = FormBuilder::getFormInputValue($fieldData, $values);
+                
         if (!is_array($value)) {
             $value = [$value];
         }

--- a/src/Filament/FormBlocks/AbstractOptionsBlock.php
+++ b/src/Filament/FormBlocks/AbstractOptionsBlock.php
@@ -9,7 +9,6 @@ use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 abstract class AbstractOptionsBlock extends AbstractFormBlock
 {
@@ -102,7 +101,7 @@ abstract class AbstractOptionsBlock extends AbstractFormBlock
     public static function displayValue($fieldData, $values): string
     {
         $value = FormBuilder::getFormInputValue($fieldData, $values);
-                
+
         if (!is_array($value)) {
             $value = [$value];
         }

--- a/src/Filament/FormBlocks/AbstractTextBlock.php
+++ b/src/Filament/FormBlocks/AbstractTextBlock.php
@@ -8,14 +8,12 @@ use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
-use Illuminate\Support\Str;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 abstract class AbstractTextBlock extends AbstractFormBlock
 {
     public function getSchema(): Closure|array
     {
-        $generalFields = [               
+        $generalFields = [
             TextInput::make('field_name')
                 ->label('Field Name')
                 ->default($this->getName())
@@ -83,7 +81,7 @@ abstract class AbstractTextBlock extends AbstractFormBlock
 
     protected static function getRequirementFields(): array
     {
-        return [            
+        return [
             FormBuilder::formFieldId(),
             Toggle::make('required')
                 ->inline(false),
@@ -91,7 +89,7 @@ abstract class AbstractTextBlock extends AbstractFormBlock
                 ->label('Max Length')
                 ->integer(true),
             TextInput::make('default_value')
-                ->label('Default Value'),                
+                ->label('Default Value'),
         ];
     }
 }

--- a/src/Filament/FormBlocks/AbstractTextBlock.php
+++ b/src/Filament/FormBlocks/AbstractTextBlock.php
@@ -8,15 +8,20 @@ use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Illuminate\Support\Str;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 abstract class AbstractTextBlock extends AbstractFormBlock
 {
     public function getSchema(): Closure|array
     {
-        $generalFields = [TextInput::make('field_name')
-        ->label('Field Name')
-        ->default($this->getName())
-        ->required()];
+        $generalFields = [               
+            TextInput::make('field_name')
+                ->label('Field Name')
+                ->default($this->getName())
+                ->required()
+        ];
+
         $typeSelector = static::getTypeSelector();
         if ($typeSelector) {
             $generalFields[] = $typeSelector;
@@ -78,14 +83,15 @@ abstract class AbstractTextBlock extends AbstractFormBlock
 
     protected static function getRequirementFields(): array
     {
-        return [
+        return [            
+            FormBuilder::formFieldId(),
             Toggle::make('required')
                 ->inline(false),
             TextInput::make('max_length')
                 ->label('Max Length')
                 ->integer(true),
             TextInput::make('default_value')
-                ->label('Default Value'),
+                ->label('Default Value'),                
         ];
     }
 }

--- a/src/Filament/FormBlocks/CheckboxBlock.php
+++ b/src/Filament/FormBlocks/CheckboxBlock.php
@@ -8,8 +8,6 @@ use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
-use Illuminate\Support\Str;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class CheckboxBlock extends AbstractTextBlock
 {
@@ -31,7 +29,7 @@ class CheckboxBlock extends AbstractTextBlock
                         ->label('Field Name')
                         ->default($this->getName())
                         ->required(),
-                    ...static::getRequirementFields(),                    
+                    ...static::getRequirementFields(),
             ]),
                 ];
     }
@@ -50,7 +48,7 @@ class CheckboxBlock extends AbstractTextBlock
         return [
             FormBuilder::formFieldId(),
             Toggle::make('required')
-                ->inline(false),                           
+                ->inline(false),
         ];
     }
 }

--- a/src/Filament/FormBlocks/CheckboxBlock.php
+++ b/src/Filament/FormBlocks/CheckboxBlock.php
@@ -8,6 +8,8 @@ use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Illuminate\Support\Str;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class CheckboxBlock extends AbstractTextBlock
 {
@@ -29,7 +31,7 @@ class CheckboxBlock extends AbstractTextBlock
                         ->label('Field Name')
                         ->default($this->getName())
                         ->required(),
-                        ...static::getRequirementFields()
+                    ...static::getRequirementFields(),                    
             ]),
                 ];
     }
@@ -46,8 +48,9 @@ class CheckboxBlock extends AbstractTextBlock
     protected static function getRequirementFields(): array
     {
         return [
+            FormBuilder::formFieldId(),
             Toggle::make('required')
-                ->inline(false),
+                ->inline(false),                           
         ];
     }
 }

--- a/src/Filament/FormBlocks/CheckboxListBlock.php
+++ b/src/Filament/FormBlocks/CheckboxListBlock.php
@@ -4,6 +4,7 @@ namespace Portable\FilaCms\Filament\FormBlocks;
 
 use Closure;
 use Filament\Forms\Components\CheckboxList;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class CheckboxListBlock extends AbstractOptionsBlock
 {
@@ -17,6 +18,8 @@ class CheckboxListBlock extends AbstractOptionsBlock
 
     protected static function getRequirementFields(): array
     {
-        return [];
+        return [                           
+            FormBuilder::formFieldId(),
+        ];
     }
 }

--- a/src/Filament/FormBlocks/CheckboxListBlock.php
+++ b/src/Filament/FormBlocks/CheckboxListBlock.php
@@ -4,7 +4,6 @@ namespace Portable\FilaCms\Filament\FormBlocks;
 
 use Closure;
 use Filament\Forms\Components\CheckboxList;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class CheckboxListBlock extends AbstractOptionsBlock
 {
@@ -18,7 +17,7 @@ class CheckboxListBlock extends AbstractOptionsBlock
 
     protected static function getRequirementFields(): array
     {
-        return [                           
+        return [
             FormBuilder::formFieldId(),
         ];
     }

--- a/src/Filament/FormBlocks/DateTimeInputBlock.php
+++ b/src/Filament/FormBlocks/DateTimeInputBlock.php
@@ -10,8 +10,6 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\TimePicker;
 use Filament\Forms\Components\Toggle;
-use Illuminate\Support\Str;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class DateTimeInputBlock extends AbstractTextBlock
 {
@@ -76,7 +74,7 @@ class DateTimeInputBlock extends AbstractTextBlock
     {
         $default = (isset($this->date_type) ? $this->date_type : DatePicker::class)::make('default_value')
             ->label('Default Value');
-        return [            
+        return [
             FormBuilder::formFieldId(),
             Toggle::make('required')
                 ->inline(false)->live(),

--- a/src/Filament/FormBlocks/DateTimeInputBlock.php
+++ b/src/Filament/FormBlocks/DateTimeInputBlock.php
@@ -10,6 +10,8 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\TimePicker;
 use Filament\Forms\Components\Toggle;
+use Illuminate\Support\Str;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class DateTimeInputBlock extends AbstractTextBlock
 {
@@ -74,7 +76,8 @@ class DateTimeInputBlock extends AbstractTextBlock
     {
         $default = (isset($this->date_type) ? $this->date_type : DatePicker::class)::make('default_value')
             ->label('Default Value');
-        return [
+        return [            
+            FormBuilder::formFieldId(),
             Toggle::make('required')
                 ->inline(false)->live(),
             $default

--- a/src/Filament/FormBlocks/FormBuilder.php
+++ b/src/Filament/FormBlocks/FormBuilder.php
@@ -5,9 +5,13 @@ namespace Portable\FilaCms\Filament\FormBlocks;
 use Filament\Forms\Components\Builder;
 use Illuminate\Support\Collection;
 use Portable\FilaCms\Facades\FilaCms;
+use Filament\Forms\Components\TextInput;
+use Illuminate\Support\Str;
 
 class FormBuilder extends Builder
 {
+    protected static $fieldId = 'field_id';
+
     public static function make(string $name): static
     {
         $availableBlocks = [];
@@ -65,7 +69,7 @@ class FormBuilder extends Builder
     {
         $html = '';
         foreach ($fieldDefs as $fieldDef) {
-            $field = FilaCms::getFormBlock($fieldDef['type']);
+            $field = FilaCms::getFormBlock($fieldDef['type']);            
             $html .= $field::displayHtml($fieldDef['data'], $values);
         }
         return $html;
@@ -74,7 +78,29 @@ class FormBuilder extends Builder
     public static function getDisplayFields($fieldData, $fieldValues): string
     {
         $builder = static::make('display');
-
         return $builder->displayHtml($fieldData, $fieldValues);
+    }
+
+    public static function formFieldId(): TextInput
+    {
+        $fieldId = Str::slug(Str::random(10));
+
+        return TextInput::make(static::$fieldId)
+                ->label('FormBuilder:field_id')
+                ->default($fieldId)
+                // ->hidden()
+                ->readOnly()
+                ->required()
+                ->afterStateHydrated(function (TextInput $component, $state) use ($fieldId) {                            
+                    if(empty($state)) {
+                        $component->state($fieldId);
+                    }
+                });
+    }
+
+    public static function getFormInputValue($fieldData, $values)
+    {
+        $fieldId = data_get($fieldData, static::$fieldId);
+        return isset($values[$fieldId]) ? $values[$fieldId] : [];        
     }
 }

--- a/src/Filament/FormBlocks/FormBuilder.php
+++ b/src/Filament/FormBlocks/FormBuilder.php
@@ -69,7 +69,7 @@ class FormBuilder extends Builder
     {
         $html = '';
         foreach ($fieldDefs as $fieldDef) {
-            $field = FilaCms::getFormBlock($fieldDef['type']);            
+            $field = FilaCms::getFormBlock($fieldDef['type']);
             $html .= $field::displayHtml($fieldDef['data'], $values);
         }
         return $html;
@@ -91,7 +91,7 @@ class FormBuilder extends Builder
                 ->hidden()
                 ->readOnly()
                 ->required()
-                ->afterStateHydrated(function (TextInput $component, $state) use ($fieldId) {                            
+                ->afterStateHydrated(function (TextInput $component, $state) use ($fieldId) {
                     if(empty($state)) {
                         $component->state($fieldId);
                     }
@@ -101,6 +101,6 @@ class FormBuilder extends Builder
     public static function getFormInputValue($fieldData, $values)
     {
         $fieldId = data_get($fieldData, static::$fieldId);
-        return isset($values[$fieldId]) ? $values[$fieldId] : [];        
+        return isset($values[$fieldId]) ? $values[$fieldId] : [];
     }
 }

--- a/src/Filament/FormBlocks/FormBuilder.php
+++ b/src/Filament/FormBlocks/FormBuilder.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
 
 class FormBuilder extends Builder
 {
-    protected static $fieldId = 'field_id';
+    public static $fieldId = 'field_id';
 
     public static function make(string $name): static
     {
@@ -88,7 +88,7 @@ class FormBuilder extends Builder
         return TextInput::make(static::$fieldId)
                 ->label('FormBuilder:field_id')
                 ->default($fieldId)
-                // ->hidden()
+                ->hidden()
                 ->readOnly()
                 ->required()
                 ->afterStateHydrated(function (TextInput $component, $state) use ($fieldId) {                            

--- a/src/Filament/FormBlocks/InformationBlock.php
+++ b/src/Filament/FormBlocks/InformationBlock.php
@@ -7,8 +7,6 @@ use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Placeholder;
 use Illuminate\Support\HtmlString;
 use Portable\FilaCms\Facades\FilaCms;
-use Illuminate\Support\Str;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class InformationBlock extends AbstractFormBlock
 {
@@ -39,7 +37,7 @@ class InformationBlock extends AbstractFormBlock
     }
 
     public static function displayValue($fieldData, $values): string
-    {        
-        return tiptap_converter()->asHTML($fieldData['contents']);       
+    {
+        return tiptap_converter()->asHTML($fieldData['contents']);
     }
 }

--- a/src/Filament/FormBlocks/InformationBlock.php
+++ b/src/Filament/FormBlocks/InformationBlock.php
@@ -7,6 +7,8 @@ use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Placeholder;
 use Illuminate\Support\HtmlString;
 use Portable\FilaCms\Facades\FilaCms;
+use Illuminate\Support\Str;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class InformationBlock extends AbstractFormBlock
 {
@@ -23,6 +25,7 @@ class InformationBlock extends AbstractFormBlock
             FilaCms::tipTapEditor('contents')
                 ->label('Contents')
                 ->required(),
+            FormBuilder::formFieldId(),
         ];
     }
 
@@ -33,5 +36,10 @@ class InformationBlock extends AbstractFormBlock
             ->content(new HtmlString(tiptap_converter()->asHTML(isset($fieldData['contents']) ? $fieldData['contents'] : ['content' => ''])));
 
         return $field;
+    }
+
+    public static function displayValue($fieldData, $values): string
+    {        
+        return tiptap_converter()->asHTML($fieldData['contents']);       
     }
 }

--- a/src/Filament/FormBlocks/RadioBlock.php
+++ b/src/Filament/FormBlocks/RadioBlock.php
@@ -4,7 +4,6 @@ namespace Portable\FilaCms\Filament\FormBlocks;
 
 use Closure;
 use Filament\Forms\Components\Radio;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class RadioBlock extends AbstractOptionsBlock
 {
@@ -17,7 +16,7 @@ class RadioBlock extends AbstractOptionsBlock
     }
     protected static function getRequirementFields(): array
     {
-        return [                           
+        return [
             FormBuilder::formFieldId(),
         ];
     }

--- a/src/Filament/FormBlocks/RadioBlock.php
+++ b/src/Filament/FormBlocks/RadioBlock.php
@@ -4,6 +4,7 @@ namespace Portable\FilaCms\Filament\FormBlocks;
 
 use Closure;
 use Filament\Forms\Components\Radio;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class RadioBlock extends AbstractOptionsBlock
 {
@@ -14,9 +15,10 @@ class RadioBlock extends AbstractOptionsBlock
     {
         return 'Radio Field';
     }
-
     protected static function getRequirementFields(): array
     {
-        return [];
+        return [                           
+            FormBuilder::formFieldId(),
+        ];
     }
 }

--- a/src/Filament/FormBlocks/RelationshipBlock.php
+++ b/src/Filament/FormBlocks/RelationshipBlock.php
@@ -17,7 +17,6 @@ use Portable\FilaCms\Models\AbstractContentModel;
 use Portable\FilaCms\Models\Author;
 use Portable\FilaCms\Models\Taxonomy;
 use Portable\FilaCms\Models\TaxonomyTerm;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class RelationshipBlock extends AbstractFormBlock
 {
@@ -27,7 +26,7 @@ class RelationshipBlock extends AbstractFormBlock
     {
         return 'Relationship Field';
     }
-    
+
 
     public function getSchema(): Closure|array
     {
@@ -48,7 +47,7 @@ class RelationshipBlock extends AbstractFormBlock
                         ->default(Select::class)
                         ->label('Component Class')
                         ->live()
-                        ->required()                    
+                        ->required()
                 ]),
                 Grid::make('settings')
                     ->columns(3)
@@ -160,7 +159,7 @@ class RelationshipBlock extends AbstractFormBlock
 
     protected static function getRequirementFields(): array
     {
-        return [                           
+        return [
             FormBuilder::formFieldId(),
             Toggle::make('required')
                 ->inline(false),
@@ -202,7 +201,7 @@ class RelationshipBlock extends AbstractFormBlock
     }
 
     public static function displayValue($fieldData, $values): string
-    {        
+    {
         $value = FormBuilder::getFormInputValue($fieldData, $values);
         if (!is_array($value)) {
             $value = [$value];

--- a/src/Filament/FormBlocks/RelationshipBlock.php
+++ b/src/Filament/FormBlocks/RelationshipBlock.php
@@ -17,6 +17,7 @@ use Portable\FilaCms\Models\AbstractContentModel;
 use Portable\FilaCms\Models\Author;
 use Portable\FilaCms\Models\Taxonomy;
 use Portable\FilaCms\Models\TaxonomyTerm;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class RelationshipBlock extends AbstractFormBlock
 {
@@ -26,6 +27,7 @@ class RelationshipBlock extends AbstractFormBlock
     {
         return 'Relationship Field';
     }
+    
 
     public function getSchema(): Closure|array
     {
@@ -46,7 +48,7 @@ class RelationshipBlock extends AbstractFormBlock
                         ->default(Select::class)
                         ->label('Component Class')
                         ->live()
-                        ->required(),
+                        ->required()                    
                 ]),
                 Grid::make('settings')
                     ->columns(3)
@@ -158,7 +160,8 @@ class RelationshipBlock extends AbstractFormBlock
 
     protected static function getRequirementFields(): array
     {
-        return [
+        return [                           
+            FormBuilder::formFieldId(),
             Toggle::make('required')
                 ->inline(false),
             Toggle::make('multiselect')
@@ -199,9 +202,8 @@ class RelationshipBlock extends AbstractFormBlock
     }
 
     public static function displayValue($fieldData, $values): string
-    {
-        $fieldName = data_get($fieldData, 'field_name');
-        $value = isset($values[$fieldName]) ? $values[$fieldName] : [];
+    {        
+        $value = FormBuilder::getFormInputValue($fieldData, $values);
         if (!is_array($value)) {
             $value = [$value];
         }

--- a/src/Filament/FormBlocks/RichTextBlock.php
+++ b/src/Filament/FormBlocks/RichTextBlock.php
@@ -4,7 +4,6 @@ namespace Portable\FilaCms\Filament\FormBlocks;
 
 use Closure;
 use Portable\FilaCms\Facades\FilaCms;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class RichTextBlock extends AbstractTextBlock
 {

--- a/src/Filament/FormBlocks/RichTextBlock.php
+++ b/src/Filament/FormBlocks/RichTextBlock.php
@@ -4,6 +4,7 @@ namespace Portable\FilaCms\Filament\FormBlocks;
 
 use Closure;
 use Portable\FilaCms\Facades\FilaCms;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class RichTextBlock extends AbstractTextBlock
 {
@@ -27,8 +28,7 @@ class RichTextBlock extends AbstractTextBlock
 
     public static function displayValue($fieldData, $values): string
     {
-        $fieldName = data_get($fieldData, 'field_name');
-        $value = isset($values[$fieldName]) ? $values[$fieldName] : [];
+        $value = FormBuilder::getFormInputValue($fieldData, $values);
 
         if (is_array($value)) {
             $value = tiptap_converter()->asHTML($value);

--- a/src/Filament/FormBlocks/SelectBlock.php
+++ b/src/Filament/FormBlocks/SelectBlock.php
@@ -5,7 +5,6 @@ namespace Portable\FilaCms\Filament\FormBlocks;
 use Closure;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
-use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class SelectBlock extends AbstractOptionsBlock
 {
@@ -19,7 +18,7 @@ class SelectBlock extends AbstractOptionsBlock
 
     protected static function getRequirementFields(): array
     {
-        return [                           
+        return [
             FormBuilder::formFieldId(),
             Toggle::make('multiselect')
                 ->inline(false)

--- a/src/Filament/FormBlocks/SelectBlock.php
+++ b/src/Filament/FormBlocks/SelectBlock.php
@@ -5,6 +5,7 @@ namespace Portable\FilaCms\Filament\FormBlocks;
 use Closure;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class SelectBlock extends AbstractOptionsBlock
 {
@@ -18,7 +19,8 @@ class SelectBlock extends AbstractOptionsBlock
 
     protected static function getRequirementFields(): array
     {
-        return [
+        return [                           
+            FormBuilder::formFieldId(),
             Toggle::make('multiselect')
                 ->inline(false)
                 ->label('Multi-select'),

--- a/src/Filament/Resources/FormEntryResource.php
+++ b/src/Filament/Resources/FormEntryResource.php
@@ -17,7 +17,6 @@ use Portable\FilaCms\Filament\Resources\FormEntryResource\Actions\ExportBulkActi
 use Portable\FilaCms\Filament\Traits\IsProtectedResource;
 use Portable\FilaCms\Models\Form as ModelsForm;
 use Portable\FilaCms\Models\FormEntry;
-use Illuminate\Support\Str;
 
 class FormEntryResource extends AbstractResource
 {
@@ -65,7 +64,7 @@ class FormEntryResource extends AbstractResource
 
         // A flat collection of all form fields
         $allFields = FormBuilder::getFieldDefinitions($form->fields);
-        
+
         $formBuilderFieldId = FormBuilder::$fieldId;
 
         foreach ($allFields as $field) {
@@ -73,7 +72,7 @@ class FormEntryResource extends AbstractResource
             if (Arr::get($field, 'type') === InformationBlock::getBlockName()) {
                 continue;
             }
-            
+
             $fieldName = Arr::get($field, 'data.field_name', null);
             $fieldId = Arr::get($field, 'data.' . $formBuilderFieldId, null);
 

--- a/src/Filament/Resources/FormEntryResource.php
+++ b/src/Filament/Resources/FormEntryResource.php
@@ -17,6 +17,7 @@ use Portable\FilaCms\Filament\Resources\FormEntryResource\Actions\ExportBulkActi
 use Portable\FilaCms\Filament\Traits\IsProtectedResource;
 use Portable\FilaCms\Models\Form as ModelsForm;
 use Portable\FilaCms\Models\FormEntry;
+use Illuminate\Support\Str;
 
 class FormEntryResource extends AbstractResource
 {
@@ -64,19 +65,23 @@ class FormEntryResource extends AbstractResource
 
         // A flat collection of all form fields
         $allFields = FormBuilder::getFieldDefinitions($form->fields);
+        
+        $formBuilderFieldId = FormBuilder::$fieldId;
+
         foreach ($allFields as $field) {
             // don't show information blocks in the table
             if (Arr::get($field, 'type') === InformationBlock::getBlockName()) {
                 continue;
             }
-
+            
             $fieldName = Arr::get($field, 'data.field_name', null);
+            $fieldId = Arr::get($field, 'data.' . $formBuilderFieldId, null);
 
-            $columns[] = Tables\Columns\TextColumn::make($fieldName)
+            $columns[] = Tables\Columns\TextColumn::make($fieldId)
                 ->label($fieldName)
-                ->getStateUsing(function ($record) use ($fieldName) {
-                    $fieldName = trim($fieldName);
-                    $value = isset($record->values[$fieldName]) ? $record->values[$fieldName] : '';
+                ->getStateUsing(function ($record) use ($fieldId) {
+                    $fieldId = trim($fieldId);
+                    $value = isset($record->values[$fieldId]) ? $record->values[$fieldId] : '';
                     if (is_array($value)) {
                         try {
                             $value = tiptap_converter()->asText($value);


### PR DESCRIPTION
I tested the form in production, and it mostly seems to be working fine with no missing text. However, certain issues arise depending on the entered field names in the data. I've identified a data content scenario that might trigger these issues and break the form:

Changing field names hides the entries in the list.
Using a dot (.) in the field name hides both the label and content.
Having the same field name but different elements (text, textarea) duplicates contents.

Solution:
Adding a unique ID for each input field instead of relying solely on the field name.