### PR TITLE
VG-389: Fix taxonomy persistence

### DIFF
--- a/src/Filament/Traits/HasTaxonomies.php
+++ b/src/Filament/Traits/HasTaxonomies.php
@@ -74,15 +74,19 @@ trait HasTaxonomies
                     $this->original[$field] = $this->attributes[$field];
                 }
             }
-            if (isset($this->attributes[$field . '_ids'])) {
-                $this->_saveTaxonomyFields[$field . '_ids'] = $this->attributes[$field . '_ids'];
-                if ($creating) {
-                    unset($this->attributes[$field . '_ids']);
-                } else {
-                    $this->original[$field] = $this->attributes[$field] = null;
-                    $this->original[$field . '_ids'] = $this->attributes[$field . '_ids'];
-                }
+            if (!isset($this->attributes[$field . '_ids'])) {
+                $caster = $this->resolveCasterClass($field . '_ids');
+                $values = $caster->get($this, $field . '_ids', null, $this->attributes);
+                $this->attributes[$field . '_ids'] = $values;
             }
+            $this->_saveTaxonomyFields[$field . '_ids'] = $this->attributes[$field . '_ids'];
+            if ($creating) {
+                unset($this->attributes[$field . '_ids']);
+            } else {
+                $this->original[$field] = $this->attributes[$field] = null;
+                $this->original[$field . '_ids'] = $this->attributes[$field . '_ids'];
+            }
+
         }
     }
 

--- a/tests/Factories/TaxonomyFactory.php
+++ b/tests/Factories/TaxonomyFactory.php
@@ -5,6 +5,7 @@ namespace Portable\FilaCms\Tests\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use Portable\FilaCms\Models\Taxonomy;
+use Portable\FilaCms\Models\TaxonomyTerm;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
@@ -25,5 +26,21 @@ class TaxonomyFactory extends Factory
             'name' => $name,
             'code' => Str::slug($name)
         ];
+    }
+
+    public function forResources(array $resources): self
+    {
+        return $this->afterCreating(function (Taxonomy $taxonomy) use ($resources) {
+            $taxonomy->resources()->createMany(array_map(function ($model) {
+                return ['resource_class' => $model];
+            }, $resources));
+        });
+    }
+
+    public function withTerms(int $count = 3): self
+    {
+        return $this->afterCreating(function (Taxonomy $taxonomy) use ($count) {
+            $taxonomy->terms()->saveMany(TaxonomyTerm::factory($count)->create(['taxonomy_id' => $taxonomy->id]));
+        });
     }
 }

--- a/tests/Unit/HasTaxonomiesTest.php
+++ b/tests/Unit/HasTaxonomiesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Portable\FilaCms\Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Portable\FilaCms\Filament\Resources\PageResource;
+use Portable\FilaCms\Models\Page;
+use Portable\FilaCms\Models\Taxonomy;
+use Portable\FilaCms\Tests\TestCase;
+
+class HasTaxonomiesTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    protected $author = null;
+
+    public function test_retrieves_tags()
+    {
+        $taxonomy = Taxonomy::factory()->withTerms()->forResources([
+            PageResource::class
+        ])->create(['name' => 'property_one']);
+
+        $model = Page::factory()->create();
+        $model->terms()->delete();
+        $model->terms()->attach($taxonomy->terms->pluck('id'));
+        $model->refresh();
+
+        $this->assertEquals($taxonomy->terms->pluck('id')->toArray(), $model->property_ones_ids->toArray());
+    }
+
+    public function test_save_keeps_tags()
+    {
+        $taxonomy = Taxonomy::factory()->withTerms()->forResources([
+            PageResource::class
+        ])->create(['name' => 'property_one']);
+
+        $model = Page::factory()->create();
+        $model->terms()->delete();
+        $model->terms()->attach($taxonomy->terms->pluck('id'));
+        $model->refresh();
+
+        $model->title = 'New Title';
+        $model->save();
+        $model->refresh();
+
+
+        $this->assertEquals($taxonomy->terms->pluck('id')->toArray(), $model->property_ones_ids->toArray());
+    }
+}


### PR DESCRIPTION
Saves to a record with HasTaxonomies were deleting existing taxonomies if they hadn't been previously accessed as a property prior to save.

Wrote a failing test for this scenario and then fixed the failure.