### PR TITLE
VG-384_Form_creation

### DIFF
--- a/src/Filament/FormBlocks/InformationBlock.php
+++ b/src/Filament/FormBlocks/InformationBlock.php
@@ -7,6 +7,7 @@ use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Placeholder;
 use Illuminate\Support\HtmlString;
 use Portable\FilaCms\Facades\FilaCms;
+use Filament\Forms\Components\TextInput;
 
 class InformationBlock extends AbstractFormBlock
 {
@@ -23,6 +24,17 @@ class InformationBlock extends AbstractFormBlock
             FilaCms::tipTapEditor('contents')
                 ->label('Contents')
                 ->required(),
+            TextInput::make('field_name')
+                ->label('Information')
+                ->default('Information')
+                ->hidden()
+                ->readOnly()
+                ->required()
+                ->afterStateHydrated(function (TextInput $component, $state) {
+                    if(empty($state)) {
+                        $component->state('Information');
+                    }
+                }),
             FormBuilder::formFieldId(),
         ];
     }

--- a/tests/Factories/FormEntryFactory.php
+++ b/tests/Factories/FormEntryFactory.php
@@ -4,6 +4,7 @@ namespace Portable\FilaCms\Tests\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Portable\FilaCms\Models\FormEntry;
+use Portable\FilaCms\Filament\FormBlocks\FormBuilder;
 
 class FormEntryFactory extends Factory
 {
@@ -18,8 +19,9 @@ class FormEntryFactory extends Factory
     {
         $fields = FormFactory::getFields();
         $values = [];
+
         foreach($fields as $field) {
-            $fieldName = data_get($field, 'data.field_name');
+            $fieldName = data_get($field, 'data.' . FormBuilder::$fieldId);
             if(!$fieldName) {
                 continue;
             }

--- a/tests/Factories/FormFactory.php
+++ b/tests/Factories/FormFactory.php
@@ -47,6 +47,7 @@ class FormFactory extends Factory
                 "type" => CheckboxBlock::getBlockName(),
                 "data" => [
                     "field_name" => "Checkbox",
+                    "field_id" => Str::slug(Str::random(10)),
                     "required" => true,
                     "default_value" => null
                 ]
@@ -55,6 +56,7 @@ class FormFactory extends Factory
                 "type" => CheckboxListBlock::getBlockName(),
                 "data" => [
                     "field_name" => "Checkbox List",
+                    "field_id" => Str::slug(Str::random(10)),
                     "required" => true,
                     "default_value" => null,
                     "options" => [
@@ -68,6 +70,7 @@ class FormFactory extends Factory
                 "type" => DateTimeInputBlock::getBlockName(),
                 "data" => [
                     "field_name" => "Date Picker",
+                    "field_id" => Str::slug(Str::random(10)),
                     "required" => true,
                     'date_type' => DatePicker::class,
                     "default_value" => null
@@ -77,6 +80,7 @@ class FormFactory extends Factory
                 "type" => InformationBlock::getBlockName(),
                 "data" => [
                     "field_name" => "Information",
+                    "field_id" => Str::slug(Str::random(10)),
                     "contents" => [
                         "type" => "paragraph",
                         "attrs" => [
@@ -97,6 +101,7 @@ class FormFactory extends Factory
                 "type" => RadioBlock::getBlockName(),
                 "data" => [
                     "field_name" => "Radio",
+                    "field_id" => Str::slug(Str::random(10)),
                     "required" => true,
                     "default_value" => null,
                     "options" => [
@@ -110,6 +115,7 @@ class FormFactory extends Factory
                 "type" => RelationshipBlock::getBlockName(),
                 "data" => [
                     "field_name" => "Relationship",
+                    "field_id" => Str::slug(Str::random(10)),
                     "required" => true,
                     "component_class" => CheckboxList::class,
                     'relationship' => PageResource::class,
@@ -120,6 +126,7 @@ class FormFactory extends Factory
                 "data" => [
                     "max_length" => 100,
                     "field_name" => "Rich Text",
+                    "field_id" => Str::slug(Str::random(10)),
                     "required" => true,
                     "default_value" => null
                 ]
@@ -128,6 +135,7 @@ class FormFactory extends Factory
                 "type" => SelectBlock::getBlockName(),
                 "data" => [
                     "field_name" => "Select",
+                    "field_id" => Str::slug(Str::random(10)),
                     "required" => true,
                     "default_value" => null,
                     "options" => [
@@ -141,6 +149,7 @@ class FormFactory extends Factory
                 "type" => TextAreaBlock::getBlockName(),
                 "data" => [
                     "field_name" => "Text Area",
+                    "field_id" => Str::slug(Str::random(10)),
                     "required" => true,
                     "max_length" => 100,
                     "default_value" => null
@@ -150,6 +159,7 @@ class FormFactory extends Factory
                 "type" => TextInputBlock::getBlockName(),
                 "data" => [
                     "field_name" => "Text Input",
+                    "field_id" => Str::slug(Str::random(10)),
                     "text_type" => "text",
                     "required" => true,
                     "max_length" => 100,


### PR DESCRIPTION
Adding form_name placeholder as fix to show proper label instead of form_id as label in "Information Block".

**Before:**

![image](https://github.com/PortableStudios/fila-cms/assets/166683621/dfe2fa6e-0e1d-4d97-a504-04bcb8e06389)


**After:**

![image](https://github.com/PortableStudios/fila-cms/assets/166683621/fceb0e5c-c472-40c6-adaf-da6f1f7da5af)
