### PR TITLE
Ensure Stop Words are updated correctly, reindex on update

### DIFF
--- a/src/Commands/SyncSearch.php
+++ b/src/Commands/SyncSearch.php
@@ -2,11 +2,14 @@
 
 namespace Portable\FilaCms\Commands;
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Console\Command;
 use Portable\FilaCms\Facades\FilaCms;
 
 class SyncSearch extends Command
 {
+    use Queueable;
+
     protected $signature = 'fila-cms:sync-search';
 
     protected $description = 'Sync search settings, flush indexes and reimport content models';

--- a/src/Jobs/ReindexSearch.php
+++ b/src/Jobs/ReindexSearch.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Portable\FilaCms\Jobs;
+
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Artisan;
+
+class ReindexSearch implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Authenticatable $user,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        Artisan::call('fila-cms:sync-search');
+        Notification::make()
+                                ->title('Search index updated')
+                                ->success()
+                                ->sendToDatabase($this->user);
+    }
+}

--- a/src/Listeners/CommandFinishedListener.php
+++ b/src/Listeners/CommandFinishedListener.php
@@ -11,12 +11,11 @@ class CommandFinishedListener
     {
         $indexCommands = ['scout:sync-index-settings','tinker','fila-cms:sync-search'];
         if(in_array($event->command, $indexCommands)) {
-
             AfterSyncSearchSettings::dispatch();
             // Now update the stop words for all the models
             // that are searchable
             $indexes = config('scout.meilisearch.index-settings');
-            $stopWords = json_decode(config('settings.search.stop-words'));
+            $stopWords = json_decode(\Portable\FilaCms\Models\Setting::get('search.stop_words'));
             if(!is_array($stopWords)) {
                 $stopWords = [];
             }


### PR DESCRIPTION
When the stop words are updated, Meilisearch needs to be re-indexed before they'll take effect.

This PR adds detection for an update to the stop words and then kicks off a queued job to reindex, with a notification to the user when done:
![image](https://github.com/user-attachments/assets/6c97c94f-9b7f-4ce4-8f7d-42e8110b29bf)

It also corrects how the stop words were being loaded in the reindex job, which was previously always resulting in blank stop words.