### PR TITLE
Fix  issue not compatible with the extended component

### DIFF
--- a/src/Filament/Forms/Components/MediaPicker.php
+++ b/src/Filament/Forms/Components/MediaPicker.php
@@ -14,7 +14,7 @@ class MediaPicker extends Field implements HasExtraItemActions
     use ConcernsHasExtraItemActions;
 
     protected string $view = 'fila-cms::filament.forms.components.media-picker';
-    protected ?bool $isLive = true;
+    protected bool | Closure | null $isLive = true;
     protected ?bool $onlyImage = false;
 
     public function onlyImage(): static


### PR DESCRIPTION
Error occuring during audit due to the $isLive variable being overridden in the MediaPicker with incompatible declaration.

https://github.com/filamentphp/forms/blob/3.x/src/Concerns/HasStateBindingModifiers.php#L17

![image](https://github.com/user-attachments/assets/0f7bb4f0-a8a3-4642-85b5-0cc8ead316b9)
