### PR TITLE
Move isLive to Setup

### DIFF
--- a/src/Filament/Forms/Components/MediaPicker.php
+++ b/src/Filament/Forms/Components/MediaPicker.php
@@ -14,7 +14,6 @@ class MediaPicker extends Field implements HasExtraItemActions
     use ConcernsHasExtraItemActions;
 
     protected string $view = 'fila-cms::filament.forms.components.media-picker';
-    protected ?bool $isLive = true;
     protected ?bool $onlyImage = false;
 
     public function onlyImage(): static
@@ -26,6 +25,7 @@ class MediaPicker extends Field implements HasExtraItemActions
 
     protected function setUp(): void
     {
+        $this->isLive = true;
         $this->registerActions([
             fn (MediaPicker $component): Action => $component->pickMediaAction(),
             fn (MediaPicker $component): Action => $component->clearMediaAction(),


### PR DESCRIPTION
Problem: Downgrading the `filament/filament` package from 3.2.113 down to the original 3.2.95 produces an issue where all modals are not accessible. There's a gray overlay that makes the modal unable to be interacted. 

However, upgrading it changes the declaration of `$isLive` from the `HasStateBindingModifiers` class (which is extended by `Component` which is extended by `MediaPicker`.

`MediaPicker` also has redeclaration of `$isLive`, instead of null, it sets it to default `True`. This specific line throws an error that I cannot resolve and cannot figure out. It throws an ErrorException with no stack trace, and I can confirm that commenting out that redeclaration makes things work again.

Solution: I tried commenting out the redeclaration, then set the $isLive via the setUp() function. I tested it on local where there's a media picker (Resources) and it seems to work with no problem.

This solution fixes the issue with faulty modal since this also allows us to upgrade `filament/filament` to 3.2.113