### PR TITLE
Feature/extend sitemap generator

### DIFF
--- a/config/fila-cms-sitemap.php
+++ b/config/fila-cms-sitemap.php
@@ -1,6 +1,6 @@
 <?php
 
-/** 
+/**
  * New file was created to ensure backwards compatibility on system
  * that already published the fila-cms config file
  */

--- a/config/fila-cms-sitemap.php
+++ b/config/fila-cms-sitemap.php
@@ -1,0 +1,14 @@
+<?php
+
+/** 
+ * New file was created to ensure backwards compatibility on system
+ * that already published the fila-cms config file
+ */
+return [
+    'exempted_words' => [
+
+    ],
+    'exempted_middleware' => [
+
+    ]
+];

--- a/src/Commands/GenerateSitemap.php
+++ b/src/Commands/GenerateSitemap.php
@@ -70,7 +70,9 @@ class GenerateSitemap extends Command
                     break;
                 }
             }
-            if (!$shouldInclude) continue;
+            if (!$shouldInclude) {
+                continue;
+            }
 
             $configExemptedMiddleware = config('fila-cms-sitemap.exempted_middleware');
             $allExemptedMiddleware = array_merge($this->exemptedMiddleware, $configExemptedMiddleware);
@@ -81,7 +83,9 @@ class GenerateSitemap extends Command
                     break;
                 }
             }
-            if (!$shouldInclude) continue;
+            if (!$shouldInclude) {
+                continue;
+            }
 
             // skip if URL is not from own
             // double slash already means it's coming out of the website

--- a/src/Commands/GenerateSitemap.php
+++ b/src/Commands/GenerateSitemap.php
@@ -62,7 +62,7 @@ class GenerateSitemap extends Command
             }
 
             $configExemptedWords = config('fila-cms-sitemap.exempted_words');
-            $allExemptedWords = array_merge($this->exemptedWorods, $configExemptedWords);
+            $allExemptedWords = array_merge($this->exemptedWords, $configExemptedWords);
 
             foreach ($allExemptedWords as $word) {
                 if ($url->startsWith($word)) {

--- a/src/Providers/FilaCmsServiceProvider.php
+++ b/src/Providers/FilaCmsServiceProvider.php
@@ -221,6 +221,7 @@ class FilaCmsServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__ . '/../../config/fila-cms.php' => config_path('fila-cms.php'),
+            __DIR__ . '/../../config/fila-cms-sitemap.php' => config_path('fila-cms-sitemap.php'),
         ], 'fila-cms-config');
 
         $this->publishes([


### PR DESCRIPTION
This should allow any projects that implements fila-cms to extend the exempted words and middlewares in the sitemap generation. This should be backward compatible.