### PR TITLE
Added fail condition when reference is lost

### DIFF
--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -84,7 +84,7 @@ class MenuItem extends Model
                 case 'index-page':
                     return route($resourceClass::getFrontendIndexRoute());
                 case 'content':
-                    $model = ($resourceClass::getModel())::find($this->reference_content);
+                    $model = ($resourceClass::getModel())::findOrFail($this->reference_content);
                     $prefix = $resourceClass::getFrontendRoutePrefix();
                     if ($prefix == '') {
                         return '/' . $model?->slug;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b1633673-0ab0-4fe1-8d36-ecb08c4e5d31)

When a referenced item on menu was deleted, the menu item will not know what to do and will result in this hard-to-debug error. Using findOrFail will at least tell us exactly which record is causing the error (below)

![image](https://github.com/user-attachments/assets/581a8d2c-0805-4d47-bf3a-5f486fb350fb)
