### PR TITLE
Fix issue with admin SSO not working

### DIFF
--- a/src/Filament/Pages/Login.php
+++ b/src/Filament/Pages/Login.php
@@ -36,7 +36,7 @@ class Login extends FilamentLogin
         foreach ($providers as $provider) {
             if (config('settings.sso.' . $provider . '.client_id') && config('settings.sso.' . $provider . '.client_secret')) {
                 $ssoButtons[] = Action::make($provider)->label('Login with ' . ucfirst($provider))->action(function () use ($provider) {
-                    return redirect()->route('sso.login', ['provider' => $provider]);
+                    return redirect()->route('login.' . $provider);
                 });
             }
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ef8e15fc-0376-4929-9ad8-96f16bab5de5)
![image](https://github.com/user-attachments/assets/6d2315f1-deef-43e4-bb25-1831553db68c)

When trying to login using SSO on the admin page (/admin), clicking on any of the 3 option will result in the 2nd image's error. This is because sso.login turns out, doesn't exist anymore or at all. The front-end link used by the /login is the login.facebook login.google and login.linkedin.