### PR TITLE
perf: memoize taxonomy order column check and optimize DynamicTermLis…

### DIFF
--- a/src/Casts/DynamicTermList.php
+++ b/src/Casts/DynamicTermList.php
@@ -15,6 +15,14 @@ class DynamicTermList implements CastsAttributes
 
     public function get($model, $key, $value, $attributes)
     {
+        // Use the eager-loaded relation when present to avoid an N+1 query per
+        // taxonomy field on list views; fall back to a scoped query otherwise.
+        if ($model->relationLoaded('terms')) {
+            return $model->terms
+                ->where('taxonomy_id', $this->taxonomyId)
+                ->values();
+        }
+
         return $model->terms()->where('taxonomy_id', $this->taxonomyId)->get();
     }
 

--- a/src/Models/Taxonomy.php
+++ b/src/Models/Taxonomy.php
@@ -39,9 +39,18 @@ class Taxonomy extends Model
 
     protected $cascadeDeletes = ['terms'];
 
+    // Memoised so the backwards-compat guard doesn't hit information_schema on
+    // every query/hydration (Doctrine introspection is slow and memory-heavy).
+    protected static ?bool $hasOrderColumn = null;
+
+    protected static function hasOrderColumn(): bool
+    {
+        return static::$hasOrderColumn ??= Schema::hasColumn('taxonomies', 'order');
+    }
+
     public function terms()
     {
-        if (Schema::hasColumn('taxonomies', 'order')) {
+        if (static::hasOrderColumn()) {
             return $this->hasMany(TaxonomyTerm::class, 'taxonomy_id')->orderBy('order');
         }
         return $this->hasMany(TaxonomyTerm::class, 'taxonomy_id');
@@ -61,7 +70,7 @@ class Taxonomy extends Model
 
     public function newQuery(): Builder
     {
-        if (Schema::hasColumn('taxonomies', 'order')) {
+        if (static::hasOrderColumn()) {
             return parent::newQuery()->orderBy('order');
         }
         return parent::newQuery();
@@ -74,7 +83,7 @@ class Taxonomy extends Model
         });
 
         static::created(function (Taxonomy $item) {
-            if (Schema::hasColumn('taxonomies', 'order')) {
+            if (static::hasOrderColumn()) {
                 // auto-add order with end of list
                 $count = Taxonomy::max('order');
                 $item->order = $count + 1;


### PR DESCRIPTION
perf: memoize taxonomy order column check and optimize DynamicTermList eager loading
- Cache hasOrderColumn() result in static property to avoid repeated Schema::hasColumn() calls (Doctrine introspection is slow/memory-heavy)
- Use eager-loaded 'terms' relation in DynamicTermList cast when available to prevent N+1 queries on list views