### PR TITLE
fix(sso): handle cancelled provider consent and missing authorization…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/*
 meili_data/*
 .phpunit.result.cache
+/docs/superpowers/*

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,3 +1,8 @@
 <x-fila-cms::layouts.app>
+  @if (session('error'))
+    <div class="mb-4 text-sm font-medium text-red-600">
+      {{ session('error') }}
+    </div>
+  @endif
   <x-fila-cms::auth.login-form />
 </x-fila-cms::layouts.app>

--- a/src/Http/Controllers/SSOController.php
+++ b/src/Http/Controllers/SSOController.php
@@ -2,9 +2,11 @@
 
 namespace Portable\FilaCms\Http\Controllers;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Contracts\LoginResponse;
@@ -13,6 +15,14 @@ use Portable\FilaCms\Models\UserSsoLink;
 
 class SSOController extends Controller
 {
+    /** Provider error codes that mean the user declined at the consent screen. */
+    protected const CANCELLED = [
+        'access_denied',            // Facebook, Google
+        'user_denied',              // Facebook, via error_reason
+        'user_cancelled_login',     // LinkedIn
+        'user_cancelled_authorize', // LinkedIn
+    ];
+
     /**
      * Show the profile for a given user.
      */
@@ -37,6 +47,12 @@ class SSOController extends Controller
     public function handleProviderCallback(LoginResponse $loginResponse)
     {
         $driver = preg_match("/login\/(.*)\//", Route::current()->uri(), $matches) ? $matches[1] : null;
+
+        // Cancelling the provider's consent screen sends the user back here with an
+        // error and no code; asking Socialite for a token would then fail hard.
+        if (!request()->filled('code')) {
+            return $this->handleMissingCode($driver);
+        }
 
         $socialiteDriver = $driver;
         if (Str::lower($socialiteDriver) === 'linkedin') {
@@ -82,5 +98,42 @@ class SSOController extends Controller
         Auth::login($ssoLink->user);
 
         return $loginResponse->toResponse(request());
+    }
+
+    /**
+     * Send the user back where they started with an explanation, rather than
+     * asking the provider to exchange an authorization code we never received.
+     */
+    protected function handleMissingCode(?string $driver): RedirectResponse
+    {
+        $label = Str::ucfirst($driver ?: 'social');
+        $error = $this->callbackParam('error');
+        $reason = $this->callbackParam('error_reason');
+
+        $cancelled = in_array($error, static::CANCELLED, true)
+            || in_array($reason, static::CANCELLED, true);
+
+        // Only a provider-reported failure is worth a log line; a bare hit on the
+        // callback is a bot or a stale bookmark, and logging those invites a flood.
+        if ($error !== null && !$cancelled) {
+            Log::warning('SSO callback reported an error instead of an authorization code', [
+                'driver' => $driver,
+                'error' => $error,
+                'error_description' => $this->callbackParam('error_description', 200),
+            ]);
+        }
+
+        return redirect()->route(Auth::check() ? 'user-profile-information.show' : 'login')
+            ->with('error', $cancelled
+                ? $label . ' login was cancelled.'
+                : 'We could not complete your ' . $label . ' login. Please try again.');
+    }
+
+    /** Callback params are attacker-controlled, so ignore anything but a plain, bounded string. */
+    protected function callbackParam(string $key, int $limit = 100): ?string
+    {
+        $value = request()->query($key);
+
+        return is_string($value) ? Str::limit($value, $limit) : null;
     }
 }

--- a/tests/Feature/SsoTest.php
+++ b/tests/Feature/SsoTest.php
@@ -5,6 +5,7 @@ namespace Portable\FilaCms\Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Socialite\Facades\Socialite;
 use Mockery;
@@ -16,6 +17,9 @@ class SsoTest extends TestCase
 {
     use WithFaker;
     use RefreshDatabase;
+
+    /** Stands in for the authorization code a provider appends to a successful callback. */
+    protected const AUTH_CODE = 'test-authorization-code';
 
     public function test_no_facebook_redirect_blank_config()
     {
@@ -95,7 +99,7 @@ class SsoTest extends TestCase
         ]);
         FilaCms::ssoRoutes();
 
-        $response = $this->get('/login/facebook/callback');
+        $response = $this->get('/login/facebook/callback?code=' . static::AUTH_CODE);
         $response->assertStatus(302);
 
         $userModel = config('auth.providers.users.model');
@@ -148,7 +152,7 @@ class SsoTest extends TestCase
             'provider_id' => $abstractUser->getId(),
         ]);
 
-        $response = $this->get('/login/facebook/callback');
+        $response = $this->get('/login/facebook/callback?code=' . static::AUTH_CODE);
         $response->assertStatus(302);
 
         $this->assertDatabaseHas('user_sso_links', [
@@ -201,7 +205,7 @@ class SsoTest extends TestCase
             'provider_refresh_token' => $abstractUser->refreshToken,
         ]);
 
-        $response = $this->get('/login/facebook/callback');
+        $response = $this->get('/login/facebook/callback?code=' . static::AUTH_CODE);
         $response->assertStatus(302);
 
         $this->assertDatabaseHas('user_sso_links', [
@@ -233,7 +237,7 @@ class SsoTest extends TestCase
         ]);
         FilaCms::ssoRoutes();
 
-        $response = $this->get('/login/linkedin/callback');
+        $response = $this->get('/login/linkedin/callback?code=' . static::AUTH_CODE);
         $response->assertStatus(302);
 
         $userModel = config('auth.providers.users.model');
@@ -286,7 +290,7 @@ class SsoTest extends TestCase
             'provider_id' => $abstractUser->getId(),
         ]);
 
-        $response = $this->get('/login/linkedin/callback');
+        $response = $this->get('/login/linkedin/callback?code=' . static::AUTH_CODE);
         $response->assertStatus(302);
 
         $this->assertDatabaseHas('user_sso_links', [
@@ -337,7 +341,7 @@ class SsoTest extends TestCase
             'provider_refresh_token' => $abstractUser->refreshToken,
         ]);
 
-        $response = $this->get('/login/linkedin/callback');
+        $response = $this->get('/login/linkedin/callback?code=' . static::AUTH_CODE);
         $response->assertStatus(302);
 
         $this->assertDatabaseHas('user_sso_links', [
@@ -346,5 +350,98 @@ class SsoTest extends TestCase
             'provider_id' => $abstractUser->getId(),
         ]);
         $this->assertAuthenticatedAs($user);
+    }
+
+    public function test_cancelled_callback_redirects_to_login_without_calling_the_provider()
+    {
+        Socialite::shouldReceive('driver')->never();
+
+        $this->configureFacebookSso();
+
+        $response = $this->get('/login/facebook/callback?error=access_denied&error_code=200&error_reason=user_denied');
+
+        $response->assertRedirect(route('login'));
+        $response->assertSessionHas('error', 'Facebook login was cancelled.');
+        $this->assertGuest();
+    }
+
+    public function test_cancelled_callback_returns_an_authenticated_user_to_their_profile()
+    {
+        Socialite::shouldReceive('driver')->never();
+
+        $this->configureFacebookSso();
+
+        $userModel = config('auth.providers.users.model');
+        $user = $userModel::create([
+            'name' => $this->faker->name,
+            'email' => $this->faker->email,
+            'password' => Hash::make(Str::random(28))
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get('/login/facebook/callback?error=access_denied&error_reason=user_denied');
+
+        $response->assertRedirect(route('user-profile-information.show'));
+        $response->assertSessionHas('error', 'Facebook login was cancelled.');
+    }
+
+    public function test_bare_callback_hit_is_turned_away_without_logging()
+    {
+        Log::spy();
+        Socialite::shouldReceive('driver')->never();
+
+        $this->configureFacebookSso();
+
+        $this->get('/login/facebook/callback')
+            ->assertRedirect(route('login'))
+            ->assertSessionHas('error');
+
+        Log::shouldNotHaveReceived('warning');
+    }
+
+    public function test_provider_reported_failure_is_logged()
+    {
+        Log::spy();
+        Socialite::shouldReceive('driver')->never();
+
+        $this->configureFacebookSso();
+
+        $this->get('/login/facebook/callback?error=invalid_scope&error_description=Bad+scope')
+            ->assertRedirect(route('login'))
+            ->assertSessionHas('error', 'We could not complete your Facebook login. Please try again.');
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn ($message, $context = []) => $context['driver'] === 'facebook'
+                && $context['error'] === 'invalid_scope'
+                && $context['error_description'] === 'Bad scope')
+            ->once();
+    }
+
+    public function test_array_error_parameter_is_ignored_rather_than_cast()
+    {
+        Socialite::shouldReceive('driver')->never();
+
+        $this->configureFacebookSso();
+
+        $this->get('/login/facebook/callback?error[]=access_denied&error_reason[]=user_denied')
+            ->assertRedirect(route('login'))
+            ->assertSessionHas('error', 'We could not complete your Facebook login. Please try again.');
+    }
+
+    public function test_login_page_shows_the_sso_failure_message()
+    {
+        $this->withSession(['error' => 'Facebook login was cancelled.'])
+            ->get(route('login'))
+            ->assertSuccessful()
+            ->assertSeeText('Facebook login was cancelled.');
+    }
+
+    protected function configureFacebookSso(): void
+    {
+        config(['settings.sso.facebook' => [
+            'client_id' => 'test',
+            'client_secret' => 'test']
+        ]);
+        FilaCms::ssoRoutes();
     }
 }


### PR DESCRIPTION
It fixes a 500 error on the SSO callback route (/login/{provider}/callback).

What was causing the error

The old callback handler went straight to Socialite:

$socialiteUser = Socialite::driver($socialiteDriver)->user();

Socialite::driver()->user() assumes the provider redirected back with an authorization code in the query string, which it then exchanges for an access token. But the callback URL gets hit in three shapes where there is no code:

1. User clicks "Cancel"/"Deny" on the provider's consent screen — the provider redirects back with ?error=access_denied&error_reason=user_denied and no code.
2. Bare hit on the callback — a bot, a stale bookmark, or a crawler requesting the URL directly, no code and no error.
3. Provider-side failure — e.g. ?error=invalid_scope, again no usable code.

In all three, Socialite tried to exchange a code that didn't exist and threw an uncaught exception → the user hit a hard error page instead of getting a graceful message. Cancelling consent is a completely normal user action, so this was a real, user-facing crash.